### PR TITLE
split cores by any whitespace not just spaces

### DIFF
--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -497,7 +497,7 @@ class MultiCoreRecipe(SolrBase):
         if "cores" not in options:
             raise zc.buildout.UserError('Attribute `cores` not defined.')
         try:
-            self.cores = [x for x in options["cores"].split(" ") if len(x) > 0]
+            self.cores = [x for x in options["cores"].split() if len(x) > 0]
         except:
             raise zc.buildout.UserError(
                     'Attribute `cores` not correct defined. Define as '


### PR DESCRIPTION
This allows the configuration of cores to be split over multiple lines, which is quite common in buildout.cfg files.
