### PR TITLE
allow to specify a template instead of configuring multiple cores with the same settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ fallback-template
     Optional. If ``collective.recipe.solrinstance:mc`` is specified as the
     recipe, then this option allows you to specify the settings that should
     be used if there is no section with the name of a core.
-    This a allows configurations like this:
+    This a allows configurations like this::
     
         [solr-instance]
         ...

--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ fallback-template
     Optional. If ``collective.recipe.solrinstance:mc`` is specified as the
     recipe, then this option allows you to specify the settings that should
     be used if there is no section with the name of a core.
-    This a allows configurations like this::
+    This allows configurations like this::
     
         [solr-instance]
         ...

--- a/README.rst
+++ b/README.rst
@@ -262,6 +262,23 @@ default-core-name
     the ``defaultCoreName`` option described at 
     http://wiki.apache.org/solr/CoreAdmin#cores.
 
+fallback-template
+    Optional. If ``collective.recipe.solrinstance:mc`` is specified as the
+    recipe, then this option allows you to specify the settings that should
+    be used if there is no section with the name of a core.
+    This a allows configurations like this:
+    
+        [solr-instance]
+        ...
+        cores = core1 core2 corex
+        template = solrcore-template
+
+        [solrcore-template]
+        basepath = /solr/${:_buildout_section_name_}
+        default-search-field = default
+        default-operator = and
+        ...
+
 Zope Integration
 ================
 

--- a/collective/recipe/solrinstance/README.txt
+++ b/collective/recipe/solrinstance/README.txt
@@ -980,3 +980,50 @@ The parameter should thus end up in ``solr.xml``:
       </cores>
     ...
 
+You can specify a fallback-template with:
+
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... parts = solr-mc
+    ...
+    ... [solr-mc]
+    ... recipe = collective.recipe.solrinstance:mc
+    ... cores = core1 core2
+    ... fallback-template = core-template
+    ...
+    ... [core-template]
+    ... unique-key = uniqueID
+    ... index =
+    ...     name:uniqueID type:uuid indexed:true stored:true default:NEW
+    ... """)
+
+Ok, let's run the buildout:
+
+    >>> print system(buildout)
+    Uninstalling solr-mc.
+    Installing solr-mc.
+    solr.xml: Generated file 'solr.xml'.
+    solrconfig.xml: Generated file 'solrconfig.xml'.
+    stopwords.txt: Generated file 'stopwords.txt'.
+    schema.xml: Generated file 'schema.xml'.
+    solrconfig.xml: Generated file 'solrconfig.xml'.
+    stopwords.txt: Generated file 'stopwords.txt'.
+    schema.xml: Generated file 'schema.xml'.
+    jetty.xml: Generated file 'jetty.xml'.
+    logging.properties: Generated file 'logging.properties'.
+    solr-instance: Generated script 'solr-instance'.
+
+The cores should end up in ``solr.xml`` although we didn't configure a core1 or core2
+section:
+
+    >>> cat(sample_buildout, 'parts', 'solr-mc', 'solr', 'solr.xml')
+    <?xml...
+    <solr persistent="true">
+    ...
+      <cores adminPath="/admin/cores">
+        <core name="core1" instanceDir="core1" />
+        <core name="core2" instanceDir="core2" />
+      </cores>
+    ...
+

--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -509,6 +509,7 @@ class MultiCoreRecipe(SolrBase):
         not_allowed_attr = set(self.options_orig.keys()) & NOT_ALLOWED_ATTR
 
         self.defaultCoreName = options.get('default-core-name', '').strip()
+        self.fallback_template = options.get('fallback-template', '').strip()
 
         if len(not_allowed_attr) != 0:
             raise zc.buildout.UserError(
@@ -551,8 +552,12 @@ class MultiCoreRecipe(SolrBase):
 
         #generate defined cores
         for core in self.cores:
-            options_core = self.buildout[core]
-            options_core = self.initSolrOpts(self.buildout, core,
+            if(self.fallback_template and core not in self.buildout):
+                options_core = self.initSolrOpts(self.buildout, core,
+                                             self.buildout[self.fallback_template])
+            else:
+                options_core = self.buildout[core]
+                options_core = self.initSolrOpts(self.buildout, core,
                                              self.buildout[core])
             conf_dir = os.path.join(solr_dir, core, "conf")
 


### PR DESCRIPTION
This a allows configurations like:

        [solr-instance]
        ...
        cores = core1 core2 corex
        template = solrcore-template

        [solrcore-template]
        basepath = /solr/${:_buildout_section_name_}
        default-search-field = default
        default-operator = and