### PR TITLE
Added additional-solrconfig-query configuration option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Change History
 4.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Added additional-solrconfig-query allowing one to extend the solrconfig.xml
+  query section.
+  [naro]
 
 
 4.0 (2013-02-15)

--- a/README.rst
+++ b/README.rst
@@ -171,6 +171,11 @@ additional-solrconfig
     Optional additional configuration to be included inside the
     ``solrconfig.xml``. For instance, ``<requestHandler />`` directives.
 
+additional-solrconfig-query
+    Optional additional configuration to be included inside the
+    query section of ``solrconfig.xml``.
+    For instance, ``<listener />`` directives.
+
 
 Cache Options
 =============
@@ -220,7 +225,7 @@ filter
     in series to either add, change or remove tokens. After all filters
     have been applied, the resulting token stream is indexed into the given
     field.
-    
+
     This option applies to the default analyzer for a given field -- by
     default, Solr considers this to apply to both ``query`` and ``index``
     analyzers.  If you want to configure separate analyzers, see the
@@ -228,7 +233,7 @@ filter
 
     Each filter is configured on a separated line and each filter will be
     applied to tokens (during Solr operation) in the order specified.
-    
+
     Each line should read like::
 
         text solr.EdgeNGramFilterFactory minGramSize="2" maxGramSize="15" side="front"
@@ -237,8 +242,8 @@ filter
 
     * ``text`` is the ``type``, one of the built-in field types;
     * ``solr.EdgeNGramFilterFactory`` is the ``class`` for this filter; and
-    * ``minGramSize="2"  maxGramSize="15" side="front"`` are the parameters 
-      for the filter's configuration. They should be formatted as XML 
+    * ``minGramSize="2"  maxGramSize="15" side="front"`` are the parameters
+      for the filter's configuration. They should be formatted as XML
       attributes.
 
     By default, for the default analyzer (being both ``query`` and ``index``):
@@ -260,7 +265,7 @@ filter
     http://wiki.apache.org/solr/AnalyzersTokenizersTokenFilters#TokenFilterFactories
 
 filter-query
-    Configure filters for default field types for ``query`` analyzers only. 
+    Configure filters for default field types for ``query`` analyzers only.
     This option is like ``filter`` but only applies to the ``query`` analyzer
     for a given field.
 
@@ -269,10 +274,10 @@ filter-query
     ``filter`` option.
 
 filter-index
-    Configure filters for default field types for ``index`` analyzers only. 
+    Configure filters for default field types for ``index`` analyzers only.
     This option is like ``filter`` but only applies to the ``index`` analyzer
     for a given field.
-    
+
     Configuration syntax is the same as the ``filter`` option above.  Options
     specified here will be added after any that apply from usage of the main
     ``filter`` option.
@@ -283,7 +288,7 @@ char-filter
     in Solr fields or queries (consuming and producing a character stream) that
     can add, change or remove characters while preserving character position
     information
-    
+
     This option applies to the default analyzer for a given field -- by
     default, Solr considers this to apply to both ``query`` and ``index``
     analyzers.  If you want to configure separate analyzers, see the
@@ -311,14 +316,14 @@ char-filter-index
     Configure character filters for default field types for ``index`` analyzers
     only.  This option is like ``char-filter`` but only applies to the
     ``index`` analyzer for a given field type.
-    
+
     Configuration syntax is the same as the ``filter`` option above.  Options
     specified here will be added after any that apply from usage of the main
     ``char filter`` option.
 
 tokenizer
     Configure tokenizers for analyzers for the default field types.
-    
+
     This option applies to the default analyzer for a given field -- by
     default, Solr considers this to apply to both ``query`` and ``index``
     analyzers.  If you want to configure separate analyzers, see the
@@ -341,7 +346,7 @@ tokenizer-query
     only.  This option is like ``tokenizer``, but only applies to the
     ``query`` analyzer for a given field type.
 
-    Configuration syntax is the same as the ``filter`` option above.  
+    Configuration syntax is the same as the ``filter`` option above.
     Options specified here will overide any that apply from usage of the main
     ``tokenizer`` option. For instance, if you specified a ``text_ws``
     tokenizer within the ``tokenizer`` option, and re-specify another
@@ -353,7 +358,7 @@ tokenizer-index
     only.  This option is like ``tokenizer``, but only applies to the
     ``index`` analyzer for a given field type.
 
-    Configuration syntax is the same as the ``filter`` option above.  
+    Configuration syntax is the same as the ``filter`` option above.
     Options specified here will overide any that apply from usage of the main
     ``tokenizer`` option. For instance, if you specified a ``text_ws``
     tokenizer within the ``tokenizer`` option, and re-specify another
@@ -404,8 +409,8 @@ cores
     to individual Solr core configurations. Each identifier specified will
     have the section it relates to processed according to the given options
     above to generate Solr configuration files for each core.  See `Multi-core
-    Solr`_ for an example.  
-    
+    Solr`_ for an example.
+
     Each identifier specified will result in a Solr ``instanceDir`` being
     created and entries for each core placed in Solr's ``solr.xml``
     configuration.

--- a/collective/recipe/solrinstance/README.txt
+++ b/collective/recipe/solrinstance/README.txt
@@ -509,6 +509,45 @@ Additional solrconfig should also be allowed:
     </foo>
     ...
 
+Additional solrconfig query section should also be allowed:
+
+    >>> rmdir(sample_buildout, 'parts', 'solr')
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... parts = solr
+    ...
+    ... [solr]
+    ... recipe = collective.recipe.solrinstance
+    ... schema-template = schema.xml
+    ... unique-key =
+    ... index =
+    ...     name:Foo type:text foo:bar another:one
+    ...     name:Bar type:text
+    ... additional-solrconfig-query =
+    ...     <listener event="firstSearcher">
+    ...         <arr />
+    ...     </listener>
+    ... """)
+    >>> print system(buildout)
+    Uninstalling solr.
+    Installing solr.
+    jetty.xml: Generated file 'jetty.xml'.
+    logging.properties: Generated file 'logging.properties'.
+    solrconfig.xml: Generated file 'solrconfig.xml'.
+    schema.xml: Generated file 'schema.xml'.
+    stopwords.txt: Generated file 'stopwords.txt'.
+    solr-instance: Generated script 'solr-instance'.
+
+    >>> cat(sample_buildout, 'parts', 'solr', 'solr', 'conf', 'solrconfig.xml')
+    <?xml version="1.0" encoding="UTF-8" ?>
+    ...
+    <listener event="firstSearcher">
+        <arr />
+    </listener>
+    </query>
+    ...
+
 Sometimes it is necessary to include extra libraries (e.g. DIH-handler,
 solr-cell, ...). You can do this with the `extralibs`-option.
 
@@ -998,7 +1037,7 @@ You can specify a default core with ``default-core-name``:
     ...
     ... [solr-mc]
     ... recipe = collective.recipe.solrinstance:mc
-    ... cores = 
+    ... cores =
     ...     core1
     ...     core2
     ... default-core-name = core1

--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -54,6 +54,7 @@ TEMPLATE_DIR = os.path.dirname(__file__)
 NOT_ALLOWED_ATTR = set(["index", "filter", "unique-key", "max-num-results",
                         "default-search-field", "default-operator",
                         "additional-solrconfig",
+                        "additional-solrconfig-query",
                         "autoCommitMaxDocs", "autoCommitMaxTime",
                         "requestParsers-multipartUploadLimitInKB"])
 
@@ -169,6 +170,8 @@ class SolrBase(object):
             'default-operator', 'OR').strip().upper()
         options['additional-solrconfig'] = options_orig.get(
             'additional-solrconfig', '').strip()
+        options['additional-solrconfig-query'] = options_orig.get(
+            'additional-solrconfig-query', '').strip()
         options['additionalSchemaConfig'] = options_orig.get(
             'additional-schema-config', '').strip()
         options['requestParsers-multipartUploadLimitInKB'] = options_orig.get(
@@ -500,6 +503,7 @@ class SolrSingleRecipe(SolrBase):
                 default_config_destination),
             rows=self.solropts['max-num-results'],
             additional_solrconfig=self.solropts['additional-solrconfig'],
+            additional_solrconfig_query=self.solropts['additional-solrconfig-query'],
             useColdSearcher=self.solropts.get('useColdSearcher', 'false'),
             maxWarmingSearchers=self.solropts.get('maxWarmingSearchers', '4'),
             requestParsers_multipartUploadLimitInKB=self.solropts[
@@ -645,6 +649,7 @@ class MultiCoreRecipe(SolrBase):
                 destination=conf_dir,
                 rows=options_core['max-num-results'],
                 additional_solrconfig=options_core['additional-solrconfig'],
+                additional_solrconfig_query=options_core['additional-solrconfig-query'],
                 useColdSearcher=options_core.get('useColdSearcher', 'false'),
                 maxWarmingSearchers=options_core.get('maxWarmingSearchers',
                                                      '4'),

--- a/collective/recipe/solrinstance/templates/solrconfig.xml.tmpl
+++ b/collective/recipe/solrinstance/templates/solrconfig.xml.tmpl
@@ -192,6 +192,8 @@
       -->
     <maxWarmingSearchers>$options.maxWarmingSearchers</maxWarmingSearchers>
 
+    $options.additional_solrconfig_query
+
   </query>
 
   <requestDispatcher handleSelect="true">

--- a/collective/recipe/solrinstance/templates4/solrconfig.xml.tmpl
+++ b/collective/recipe/solrinstance/templates4/solrconfig.xml.tmpl
@@ -456,6 +456,8 @@
       -->
     <maxWarmingSearchers>$options.maxWarmingSearchers</maxWarmingSearchers>
 
+    $options.additional_solrconfig_query
+
   </query>
 
 


### PR DESCRIPTION
...ecify additional config inside a <query /> section. It is useful for specifying <listener/> for example
