### PR TITLE
Able to run buildout without breaking the running solr instance (#12)

### DIFF
--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -504,11 +504,6 @@ class SolrSingleRecipe(SolrBase):
 
     def install(self):
         """installer"""
-        self.generated = [self.install_dir]
-
-        if os.path.exists(self.install_dir):
-            shutil.rmtree(self.install_dir)
-
         # Copy the instance files
         self.copysolr(os.path.join(self.instanceopts['solr-location'],
                                    'example'), self.install_dir)
@@ -614,7 +609,7 @@ class SolrSingleRecipe(SolrBase):
             startcmd=self.parse_java_opts(self.instanceopts))
 
         # returns installed files
-        return self.generated
+        return ()
 
     def update(self):
         """
@@ -650,11 +645,6 @@ class MultiCoreRecipe(SolrBase):
 
     def install(self):
         """installer"""
-        self.generated = [self.install_dir]
-
-        if os.path.exists(self.install_dir):
-            shutil.rmtree(self.install_dir)
-
         # Copy the instance files
         self.copysolr(os.path.join(self.instanceopts['solr-location'],
                                    'example'), self.install_dir)
@@ -784,8 +774,7 @@ class MultiCoreRecipe(SolrBase):
                 self.instanceopts['port']),
             startcmd=self.parse_java_opts(self.instanceopts))
 
-        # returns installed files
-        return self.generated
+        return ()
 
     def update(self):
         """


### PR DESCRIPTION
This PR fixes #12.

As I said in the ticket, update() doesn't really do anything useful. It's handy if you want your recipe to run _every_ time, but if you only want it to run when the part settings have changed then you only want the install() method.

This isn't enough because the uninstall()/install() is called every buildout (if you use it direct from git) or at least every time you change the schema or other part settings. So I don't tell buildout which files I created (to avoid its auto-uninstall code) and I now use a variant of copysolr that is safe to run over and over again, so that install is non-destructive.
