### PR TITLE
Default request handler components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Change History
 6.0.0b4 (unreleased)
 ====================
 
-- Nothing changed yet.
+- Added option defaultHandlerComponents
+  [reinhardt]
 
 
 6.0.0b3 (2015-04-22)

--- a/README.rst
+++ b/README.rst
@@ -212,6 +212,12 @@ directoryFactory
     If you are running a solr-instance for unit-testing of an
     application it could be useful to use solr.RAMDirectoryFactory.
 
+defaultHandlerComponents
+    Additional components that will be added to the default request handler.
+    This is a list of component names - note that the actual components need
+    to be defined in the configuration separately (either by default or using 
+    additional-solrconfig).
+
 additional-solrconfig
     Optional additional configuration to be included inside the
     ``solrconfig.xml``. For instance, ``<requestHandler />`` directives.

--- a/collective/recipe/solrinstance/README.txt
+++ b/collective/recipe/solrinstance/README.txt
@@ -557,6 +557,48 @@ Without the custom template for `schema.xml` this should yield an error:
     ...
     Error: Invalid index attribute(s): foo. Allowed attributes are: ...
 
+Additional components can be added to the default request handler
+using defaultHandlerComponents:
+
+    >>> rmdir(sample_buildout, 'parts', 'solr')
+    >>> write(sample_buildout, 'buildout.cfg',
+    ... """
+    ... [buildout]
+    ... parts = solr
+    ...
+    ... [solr]
+    ... recipe = collective.recipe.solrinstance
+    ... solr-version = 3
+    ... solr-location = {0}
+    ... schema-template = schema.xml
+    ... unique-key =
+    ... index =
+    ...     name:Foo type:text foo:bar another:one
+    ...     name:Bar type:text
+    ... defaultHandlerComponents =
+    ...     elevator
+    ... """.format(sample_buildout))
+    >>> print(system(buildout))
+    Installing solr.
+    solr: Generated file 'jetty.xml'.
+    solr: Generated file 'log4j.properties'.
+    solr: Generated file 'logging.properties'.
+    solr: Generated script 'solr-instance'.
+    solr: Generated file 'solrconfig.xml'.
+    solr: Generated file 'schema.xml'.
+    solr: Generated file 'stopwords.txt'.
+    solr: Generated file 'synonyms.txt'.
+
+    >>> cat(sample_buildout, 'parts', 'solr', 'solr', 'conf', 'solrconfig.xml')
+    <?xml version="1.0" encoding="UTF-8" ?>
+    ...
+        <arr name="last-components">
+    ...
+          <str>elevator</str>
+    ...
+      </requestHandler>
+    ...
+
 Additional solrconfig should also be allowed:
 
     >>> rmdir(sample_buildout, 'parts', 'solr')
@@ -580,6 +622,7 @@ Additional solrconfig should also be allowed:
     ...     </foo>
     ... """.format(sample_buildout))
     >>> print(system(buildout))
+    Uninstalling solr.
     Installing solr.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.

--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -266,6 +266,13 @@ class MultiCoreSolrRecipe(object):
 
         return extralibs
 
+    def get_default_handler_components(self, options):
+        components = []
+        option_dhc = options.get('defaultHandlerComponents', '').strip()
+        for comp in option_dhc.splitlines():
+            components.append(comp.strip())
+        return components
+
     def copy_solr(self, source, destination):
         for sourcedir, dirs, files in os.walk(source):
             relpath = os.path.relpath(sourcedir, source)
@@ -656,6 +663,8 @@ class MultiCoreSolrRecipe(object):
 
         # Config
         self._generate_from_template(
+            default_handler_components=self.get_default_handler_components(
+                options),
             additional_solrconfig=options['additional-solrconfig'],
             additional_solrconfig_query=options[
                 'additional-solrconfig-query'],

--- a/collective/recipe/solrinstance/templates/3/solrconfig.xml.tmpl
+++ b/collective/recipe/solrinstance/templates/3/solrconfig.xml.tmpl
@@ -254,6 +254,9 @@
 
     <arr name="last-components">
       <str>spellcheck</str>
+      {% for component in options.default_handler_components %}
+      <str>${component}</str>
+      {% end %}
     </arr>
 
   </requestHandler>

--- a/collective/recipe/solrinstance/templates/4/solrconfig.xml.tmpl
+++ b/collective/recipe/solrinstance/templates/4/solrconfig.xml.tmpl
@@ -644,6 +644,13 @@
          <str>nameOfCustomComponent2</str>
        </arr>
       -->
+     {%if options.default_handler_components %}
+     <arr name="last-components">
+        {% for component in options.default_handler_components %}
+        <str>${component}</str>
+        {% end %}
+     </arr>
+     {% end %}
     </requestHandler>
 
   <!-- A request handler that returns indented JSON by default -->

--- a/collective/recipe/solrinstance/templates/5/solrconfig.xml.tmpl
+++ b/collective/recipe/solrinstance/templates/5/solrconfig.xml.tmpl
@@ -644,6 +644,13 @@
          <str>nameOfCustomComponent2</str>
        </arr>
       -->
+     {%if options.default_handler_components %}
+     <arr name="last-components">
+        {% for component in options.default_handler_components %}
+        <str>${component}</str>
+        {% end %}
+     </arr>
+     {% end %}
     </requestHandler>
 
   <!-- A request handler that returns indented JSON by default -->


### PR DESCRIPTION
In order to activate things like elevation for the default request handler we need to be able to add components to it. The new option defaultHandlerComponents allows just that.