### PR TITLE
[5.x] Fix schema and stop words template location

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Change History
 - Update request handler in ``solrconfig.xml`` to avoid deprecation warnings
   for SOLR 4.  [mgrbyte]
 
+- Fix schema and stop words template location.
+  [gforcada]
 
 5.3.2 (2014-08-27)
 ==================

--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -167,11 +167,8 @@ class SolrBase(object):
 
         options['config-template'] = options_orig.get('config-template')
         options["customTemplate"] = "schema-template" in options_orig
-        options["schema-template"] = options_orig.get('schema-template',
-                '%s/schema.xml.tmpl' % self.tpldir)
-        options['stopwords-template'] = options_orig.get(
-            'stopwords-template',
-            '%s/stopwords.txt.tmpl' % self.tpldir)
+        options["schema-template"] = options_orig.get('schema-template', '')
+        options['stopwords-template'] = options_orig.get('stopwords-template', '')
         options['config-destination'] = options_orig.get('config-destination')
         options['schema-destination'] = options_orig.get('schema-destination')
 
@@ -631,16 +628,20 @@ class SolrSingleRecipe(SolrBase):
             directoryFactory=self.solropts['directoryFactory'],
             )
 
+        default_source = '%s/schema.xml.tmpl' % self.tpldir
+        source = self.solropts.get('schema-template') or default_source
         self.generate_solr_schema(
-            source=self.solropts.get('schema-template'),
+            source=source,
             destination=(self.solropts['schema-destination'] or
                 default_config_destination),
             analyzers=self.parse_analyzer(self.solropts),
             indeces=self.parse_index(self.solropts),
             options=self.solropts)
 
+        default_source = '%s/stopwords.txt.tmpl' % self.tpldir
+        source = self.solropts.get('stopwords-template') or default_source
         self.generate_stopwords(
-            source=self.solropts.get('stopwords-template'),
+            source=source,
             destination=(self.solropts['config-destination'] or
                 default_config_destination),
             )
@@ -804,15 +805,17 @@ class MultiCoreRecipe(SolrBase):
                 directoryFactory=options_core['directoryFactory'],
                 )
 
+            default_source = '%s/stopwords.txt.tmpl' % self.tpldir
+            source = options_core.get('stopwords-template') or default_source
             self.generate_stopwords(
-                source=options_core.get('stopwords-template',
-                    '%s/stopwords.txt.tmpl' % self.tpldir),
+                source=source,
                 destination=conf_dir,
                 )
 
+            default_source = '%s/schema.xml.tmpl' % self.tpldir
+            source = options_core.get('schema-template') or default_source
             self.generate_solr_schema(
-                source=options_core.get('schema-template',
-                    '%s/schema.xml.tmpl' % self.tpldir),
+                source=source,
                 destination=conf_dir,
                 analyzers=self.parse_analyzer(options_core),
                 indeces=self.parse_index(options_core),


### PR DESCRIPTION
Buildout first initializes a recipe, then installs it and even later updates it.

As solr configuration depends on downloading solr
(done in a separate part with its own initialize, install and update),
checking for a file to exist on the other (download) part does not work on the initial phase,
but does on the install.

At the same time this recipe allows to override some templates,
so if the template is not overriden, an empty string is used (on the init phase).

Thus on the install phase, a correct path can be built.

@tisto I went ahead and created the 5.x branch. This the fix I'm currently using to make 5.3.2 actually work.