### PR TITLE
field type names are case sensitive

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Change History
 6.0.0b4 (unreleased)
 ====================
 
+- Allow for case sensitive field type names, fix testing
+  [tschorr]
+
 - Add option ``global-extra-libs``.
   [do3cc]
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,5 +1,4 @@
 [buildout]
-extensions = mr.developer
 extends = versions.cfg
 versions = versions
 show-picked-versions = true

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,4 +1,5 @@
 [buildout]
+extensions = mr.developer
 extends = versions.cfg
 versions = versions
 show-picked-versions = true
@@ -6,6 +7,7 @@ parts = test
     code-analysis
 
 prefer-final = false
+develop = .
 
 [test]
 recipe = zc.recipe.testrunner

--- a/collective/recipe/solrinstance/README.txt
+++ b/collective/recipe/solrinstance/README.txt
@@ -30,6 +30,7 @@ extracted in the parts directory:
     ...     name:Foo bar type:text
     ...     name:Baz type:text
     ...     name:Everything type:text
+    ...     name:camelCaseType type:alphaOnlySort stored:false
     ... tokenizer =
     ...     text solr.KeywordTokenizerFactory
     ... filter =
@@ -86,6 +87,7 @@ Check if the run script is here and the template substitution worked:
     SOLR_DIR = r'.../parts/solr'
     ...
     START_CMD = ['java', '-jar', ... 'start.jar']
+    ...
     UPDATE_URL = r'http://127.0.0.1:1234/solr/update'
     ...
 
@@ -121,6 +123,7 @@ And make sure the substitution worked for all files.
     >>> cat(sample_buildout, 'parts', 'solr', 'solr', 'collection1', 'conf', 'schema.xml')
     <?xml version="1.0" encoding="UTF-8" ?>
     ...
+
     <filter class="Baz" foo="bar" juca="bala"/>
     ...
     <charFilter class="solr.HTMLStripCharFilterFactory" />
@@ -128,6 +131,8 @@ And make sure the substitution worked for all files.
     <filter class="solr.ISOLatin1AccentFilterFactory" />
     ...
     <tokenizer class="solr.KeywordTokenizerFactory" />
+    ...
+    <fieldType name="alphaOnlySort" class="solr.TextField" sortMissingLast="true" omitNorms="true">
     ...
     <field name="uniqueID" type="string" indexed="true"
            stored="true" required="true" multiValued="false"
@@ -156,6 +161,11 @@ And make sure the substitution worked for all files.
            />
     <field name="Everything" type="text" indexed="true"
            stored="true" required="false" multiValued="false"
+           termVectors="false" termPositions="false"
+           termOffsets="false"
+           />
+    <field name="camelCaseType" type="alphaOnlySort" indexed="true"
+           stored="false" required="false" multiValued="false"
            termVectors="false" termPositions="false"
            termOffsets="false"
            />

--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -465,10 +465,8 @@ class MultiCoreSolrRecipe(object):
                 if key == 'copyfield':
                     entry[key] = [{'source': entry['name'], 'dest':val}
                                   for val in value]
-                elif key in ('name', 'extras', 'default'):
+                elif key in ('name', 'extras', 'default', 'type'):
                     entry[key] = value
-                elif key == 'type':
-                    entry[key] = value.lower()
                 elif key in ('omitnorms',
                              'storeOffsetsWithPositions') and not value:
                     # don't override omitNorms default value

--- a/collective/recipe/solrinstance/tests/base.py
+++ b/collective/recipe/solrinstance/tests/base.py
@@ -41,7 +41,7 @@ additionalFieldConfig =
    <dynamicField name="*_public" type="string" indexed="true" stored="true"  multiValued="true"/>
    <dynamicField name="*_restricted" type="string" indexed="true" stored="true"  multiValued="true"/>
 
-global-extra-libs = {global_extra_libs:s}
+global-extra-libs = {{global_extra_libs:s}}
 
 char-filter =
     text_ws solr.HTMLStripCharFilterFactory

--- a/collective/recipe/solrinstance/tests/test_solr_4.py
+++ b/collective/recipe/solrinstance/tests/test_solr_4.py
@@ -102,7 +102,7 @@ solr-location={1}
 
         # Jetty
         jetty_file = self.getfile('parts', 'solr-mc', 'etc', 'jetty.xml')
-        self.assertTrue('<Set name="port">1234</Set>' in jetty_file)
+        self.assertTrue('<Set name="port"><SystemProperty name="jetty.port" default="1234" /></Set>' in jetty_file)  # noqa
 
         # Script
         solr_instance_script = self.getfile('bin', 'solr-instance')

--- a/versions.cfg
+++ b/versions.cfg
@@ -11,6 +11,7 @@ zope.exceptions = 3.6.1
 zope.interface = 3.6.1
 zope.testing = 3.10.2
 zope.testrunner = 4.0.3
+check-manifest=0.25
 
 [versions3]
 <= versions


### PR DESCRIPTION
The recipe normalizes field type names, but they are actually case sensitive. E.g. the default schema template contains a field type `alphaOnlySort` that cannot be used because the recipe renders it as `alphaonlysort`.

The PR also contains a fix for `buildout.cfg` making it use the source package (again). The current master `buildout.cfg` obviously uses the latest PyPI release of c.r.solrinstance. Therefore also some older tests needed fixing.