### PR TITLE
Drop Python 2.6 support, use Python 3.5 (instead of 3.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
 python:
-  - 2.6
   - 2.7
-  - 3.3
+  - 3.5
 matrix:
   allow_failures:
-    - python: 3.3
+    - python: 3.5
 install:
   - mkdir -p buildout-cache/eggs
   - mkdir -p buildout-cache/downloads

--- a/versions.cfg
+++ b/versions.cfg
@@ -11,7 +11,6 @@ zope.exceptions = 3.6.1
 zope.interface = 3.6.1
 zope.testing = 3.10.2
 zope.testrunner = 4.0.3
-check-manifest=0.25
 
 [versions3]
 <= versions


### PR DESCRIPTION
see #56