### PR TITLE
When the `cores` option is not used, use `collection1` as core name.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Change History
 6.0.0b4 (unreleased)
 ====================
 
+- When the ``cores`` option is not used, use ``collection1`` as core name.
+  This eases migration from previous versions of this recipe.
+  `Issue #43 <https://github.com/collective/collective.recipe.solrinstance/issues/43>`_.
+  [maurits]
+
 - Allow for case sensitive field type names, fix testing
   [tschorr]
 

--- a/README.rst
+++ b/README.rst
@@ -215,7 +215,7 @@ directoryFactory
 defaultHandlerComponents
     Additional components that will be added to the default request handler.
     This is a list of component names - note that the actual components need
-    to be defined in the configuration separately (either by default or using 
+    to be defined in the configuration separately (either by default or using
     additional-solrconfig).
 
 additional-solrconfig

--- a/collective/recipe/solrinstance/README.txt
+++ b/collective/recipe/solrinstance/README.txt
@@ -1040,6 +1040,8 @@ Testing multicore recipe without cores:
     ... port = 1234
     ... max-num-results = 99
     ... section-name = SOLR
+    ... unique-key =
+    ... index =
     ... java_opts =
     ...     -Xms512M
     ...     -Xmx1024M
@@ -1050,11 +1052,12 @@ Ok, let's run the buildout:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr-mc.
-    While:
-      Installing solr-mc.
-    Error: Missing option: solr-mc:cores
+    solr-mc: No cores option defined. Using collection1.
+    ...
+    collection1: Generated file 'solrconfig.xml'.
+    ...
 
-Testing multicore recipe with wrong cores:
+Testing multicore recipe without cores:
 
     >>> write(sample_buildout, 'buildout.cfg',
     ... """
@@ -1070,6 +1073,8 @@ Testing multicore recipe with wrong cores:
     ... port = 1234
     ... max-num-results = 99
     ... section-name = SOLR
+    ... unique-key =
+    ... index =
     ... java_opts =
     ...     -Xms512M
     ...     -Xmx1024M
@@ -1078,12 +1083,12 @@ Testing multicore recipe with wrong cores:
 Ok, let's run the buildout:
 
     >>> print(system(buildout))
+    Uninstalling solr-mc.
     Installing solr-mc.
-    While:
-      Installing solr-mc.
-    Error: Attribute `cores` is not correctly defined. Define as a whitespace
-    or line separated list like `cores = X1 X2 X3`
-
+    solr-mc: No cores option defined. Using collection1.
+    ...
+    collection1: Generated file 'solrconfig.xml'.
+    ...
 
 Note that you can specify the ``cores`` option as either newline separated or
 other whitespace separated.
@@ -1167,6 +1172,7 @@ Test our first core:
 Ok, let's run the buildout:
 
     >>> print(system(buildout))
+    Uninstalling solr-mc.
     Installing solr-mc.
     solr-mc: Generated file 'jetty.xml'.
     solr-mc: Generated file 'log4j.properties'.

--- a/collective/recipe/solrinstance/README.txt
+++ b/collective/recipe/solrinstance/README.txt
@@ -65,6 +65,7 @@ Ok, let's run the buildout:
 
     >>> print(system(buildout))
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -252,6 +253,7 @@ Files should support Unicode output if present in templates::
 
     >>> print(system(buildout))
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -362,6 +364,7 @@ With the index set up correctly, things work again:
     ... """.format(sample_buildout))
     >>> print(system(buildout))
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -397,6 +400,7 @@ There's no default for the default search field, however:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -441,6 +445,7 @@ You can also define extra field types:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -501,6 +506,7 @@ to be used to generate `schema.xml`:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -545,6 +551,7 @@ variable that can then be conveniently used in the template:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -605,6 +612,7 @@ using defaultHandlerComponents:
     ... """.format(sample_buildout))
     >>> print(system(buildout))
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -650,6 +658,7 @@ Additional solrconfig should also be allowed:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -693,6 +702,7 @@ Additional solrconfig query section should also be allowed:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -735,6 +745,7 @@ solr-cell, ...). You can do this with the `extralibs`-option.
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -776,6 +787,7 @@ Test autoCommit arguments:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -815,6 +827,7 @@ Testing the request parsers default limit:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -852,6 +865,7 @@ Test changing the request parsers limit:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -892,6 +906,7 @@ alternative template to be used to generate `solrconfig.xml`:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -943,6 +958,7 @@ Solr instances to coexist in a single buildout:
     >>> print(system(buildout))
     Uninstalling solr.
     Installing solr-main.
+    solr-main: No cores option defined. Using collection1.
     solr-main: Generated file 'jetty.xml'.
     solr-main: Generated file 'log4j.properties'.
     solr-main: Generated file 'logging.properties'.
@@ -953,6 +969,7 @@ Solr instances to coexist in a single buildout:
     collection1: Generated file 'stopwords.txt'.
     collection1: Generated file 'synonyms.txt'.
     Installing solr-functest.
+    solr-functest: No cores option defined. Using collection1.
     solr-functest: Generated file 'jetty.xml'.
     solr-functest: Generated file 'log4j.properties'.
     solr-functest: Generated file 'logging.properties'.
@@ -998,6 +1015,7 @@ Ok, let's run the buildout:
     Uninstalling solr-functest.
     Uninstalling solr-main.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.
@@ -1429,6 +1447,7 @@ Ok, let's run the buildout:
     >>> print(system(buildout))
     Uninstalling solr-mc.
     Installing solr.
+    solr: No cores option defined. Using collection1.
     solr: Generated file 'jetty.xml'.
     solr: Generated file 'log4j.properties'.
     solr: Generated file 'logging.properties'.

--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -17,6 +17,8 @@ DEFAULT_DOWNLOAD_URLS = {
     4: 'http://archive.apache.org/dist/lucene/solr/4.10.4/solr-4.10.4.tgz',
 }
 
+STANDARD_CORE_NAME = 'collection1'
+
 ZOPE_CONF = """
 <product-config {section-name:s}>
     address {host:s}:{port:s}
@@ -421,7 +423,7 @@ class MultiCoreSolrRecipe(object):
         indexAttrs = set(INDEX_ATTRIBUTES.keys())
         indeces = []
         names = []
-        for line in options['index'].strip().splitlines():
+        for line in options.get('index', '').strip().splitlines():
             if line.strip().startswith('#'):
                 continue  # Allow comments
             entry = {}
@@ -555,7 +557,7 @@ class MultiCoreSolrRecipe(object):
     @property
     def cores(self):
         cores = []
-        for core in self.options['cores'].split():
+        for core in self.options.get('cores', '').split():
             if core in cores:
                 raise zc.buildout.UserError(
                     'Core {0} was already defined.'.format(repr(core)))
@@ -563,10 +565,9 @@ class MultiCoreSolrRecipe(object):
             cores.append(core.strip())
 
         if not cores:
-            raise zc.buildout.UserError(
-                'Attribute `cores` is not correctly defined. Define as a '
-                'whitespace or line separated list like `cores = X1 X2 X3`'
-            )
+            cores = [STANDARD_CORE_NAME]
+            self.logger.info('No cores option defined. Using %s.',
+                             STANDARD_CORE_NAME)
 
         return cores
 
@@ -809,7 +810,7 @@ class SingleCoreSolrRecipe(MultiCoreSolrRecipe):
     """Builds a single core solr setup - DEPRECATED"""
 
     # This collection1 demo core is used by solr 4 only.
-    cores = ['collection1', ]
+    cores = [STANDARD_CORE_NAME, ]
 
     def install(self):
         if self.solr_version < 4:

--- a/collective/recipe/solrinstance/__init__.py
+++ b/collective/recipe/solrinstance/__init__.py
@@ -556,6 +556,8 @@ class MultiCoreSolrRecipe(object):
 
     @property
     def cores(self):
+        if hasattr(self, '_cores'):
+            return self._cores
         cores = []
         for core in self.options.get('cores', '').split():
             if core in cores:
@@ -569,6 +571,7 @@ class MultiCoreSolrRecipe(object):
             self.logger.info('No cores option defined. Using %s.',
                              STANDARD_CORE_NAME)
 
+        self._cores = cores
         return cores
 
     def install_base(self):
@@ -807,21 +810,17 @@ class MultiCoreSolrRecipe(object):
 
 
 class SingleCoreSolrRecipe(MultiCoreSolrRecipe):
-    """Builds a single core solr setup - DEPRECATED"""
+    """Builds a single core solr setup.
 
-    # This collection1 demo core is used by solr 4 only.
-    cores = [STANDARD_CORE_NAME, ]
+    'collection1' is used as default core name.  But if a 'cores' option
+    is specified anyway, this works fine for multi core.
+    """
 
     def install(self):
         if self.solr_version < 4:
+            self._cores = [STANDARD_CORE_NAME]
             self.install_base()
             self.install_core(self.name, self.options)
             return (self.options['location'], )
 
-        if self.solr_version == 4:
-            return super(SingleCoreSolrRecipe, self).install()
-
-        raise zc.buildout.UserError(
-            'Solr {0} no longer supports deprecated single core setups. '
-            'Please use a multicore setup with one core.'.format(
-                self.solr_version))
+        return super(SingleCoreSolrRecipe, self).install()

--- a/collective/recipe/solrinstance/tests/test_solr_5.py
+++ b/collective/recipe/solrinstance/tests/test_solr_5.py
@@ -28,10 +28,13 @@ class Solr5TestCase(Solr4xTestCase):
             self.assertNotIn('apache-', c['config'])
 
     def test_singlecore_install(self):
+        # We refused single core for Solr 5 for a while,
+        # but we now just do a multicore setup with one core.
         output = self._basic_singlecore_install()
-        self.assertIn('Error: Solr 5 no longer supports deprecated single '
-                      'core setups. Please use a multicore setup with one '
-                      'core.', output)
+        self.assertIn(
+            'solr: No cores option defined. Using collection1.', output)
+        self.assertIn(
+            "collection1: Generated file 'solrconfig.xml'", output)
 
     def test_core_configuration_on_multicore_install(self):
         out = self._basic_multicore_install()


### PR DESCRIPTION
This eases migration from previous versions of this recipe.
See issue #43.

Note that I did not want to reuse the `default-core-name` option, because that option has other goals, and is deprecated and no longer used in Solr 5.